### PR TITLE
Support both /reel and /reels Instagram URLs

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ SERVICES = {
         "display_format": "Twitter • {0}"
     },
     "Instagram": {
-        "patterns": [r"instagram\.com/(?:p|reel)/([\w-]+)"],
+        "patterns": [r"instagram\.com/(?:p|reels?)/([\w-]+)"],
         "base_url": "fixembed.app",
         "display_format": "Instagram • {0}"
     },

--- a/service/README.md
+++ b/service/README.md
@@ -67,6 +67,7 @@ Direct URL patterns for easy use:
 GET /twitter/{user}/status/{id}
 GET /instagram/p/{shortcode}
 GET /instagram/reel/{shortcode}
+GET /instagram/reels/{shortcode}
 GET /threads/@{username}/post/{shortcode}
 GET /bluesky/profile/{handle}/post/{id}
 GET /reddit/r/{subreddit}/comments/{id}

--- a/service/src/README.md
+++ b/service/src/README.md
@@ -67,6 +67,7 @@ Direct URL patterns for easy use:
 GET /twitter/{user}/status/{id}
 GET /instagram/p/{shortcode}
 GET /instagram/reel/{shortcode}
+GET /instagram/reels/{shortcode}
 GET /threads/@{username}/post/{shortcode}
 GET /bluesky/profile/{handle}/post/{id}
 GET /reddit/r/{subreddit}/comments/{id}

--- a/service/src/handlers/instagram.ts
+++ b/service/src/handlers/instagram.ts
@@ -280,8 +280,7 @@ export const instagramHandler: PlatformHandler = {
     name: 'instagram',
     patterns: [
         /instagram\.com\/p\/([^\/\?]+)/i,
-        /instagram\.com\/reel\/([^\/\?]+)/i,
-        /instagram\.com\/reels\/([^\/\?]+)/i,
+        /instagram\.com\/reels?\/([^\/\?]+)/i,
         /instagram\.com\/tv\/([^\/\?]+)/i,
         /instagram\.com\/stories\/([^\/]+)\/(\d+)/i,
         /instagram\.com\/share\/(p|reel)\/([^\/\?]+)/i,

--- a/service/src/src/handlers/instagram.ts
+++ b/service/src/src/handlers/instagram.ts
@@ -280,8 +280,7 @@ export const instagramHandler: PlatformHandler = {
     name: 'instagram',
     patterns: [
         /instagram\.com\/p\/([^\/\?]+)/i,
-        /instagram\.com\/reel\/([^\/\?]+)/i,
-        /instagram\.com\/reels\/([^\/\?]+)/i,
+        /instagram\.com\/reels?\/([^\/\?]+)/i,
         /instagram\.com\/tv\/([^\/\?]+)/i,
         /instagram\.com\/stories\/([^\/]+)\/(\d+)/i,
         /instagram\.com\/share\/(p|reel)\/([^\/\?]+)/i,

--- a/service/src/src/utils/fetch.ts
+++ b/service/src/src/utils/fetch.ts
@@ -112,7 +112,7 @@ export function parseRedditUrl(url: string): { subreddit: string; postId: string
 export function parseInstagramUrl(url: string): { shortcode: string; type: 'post' | 'reel' | 'story' } | null {
     const patterns = [
         { pattern: /instagram\.com\/p\/([^\/\?]+)/i, type: 'post' as const },
-        { pattern: /instagram\.com\/reel\/([^\/\?]+)/i, type: 'reel' as const },
+        { pattern: /instagram\.com\/reels?\/([^\/\?]+)/i, type: 'reel' as const },
         { pattern: /instagram\.com\/stories\/[^\/]+\/(\d+)/i, type: 'story' as const },
     ];
 

--- a/service/src/utils/fetch.ts
+++ b/service/src/utils/fetch.ts
@@ -112,7 +112,7 @@ export function parseRedditUrl(url: string): { subreddit: string; postId: string
 export function parseInstagramUrl(url: string): { shortcode: string; type: 'post' | 'reel' | 'story' } | null {
     const patterns = [
         { pattern: /instagram\.com\/p\/([^\/\?]+)/i, type: 'post' as const },
-        { pattern: /instagram\.com\/reel\/([^\/\?]+)/i, type: 'reel' as const },
+        { pattern: /instagram\.com\/reels?\/([^\/\?]+)/i, type: 'reel' as const },
         { pattern: /instagram\.com\/stories\/[^\/]+\/(\d+)/i, type: 'story' as const },
     ];
 


### PR DESCRIPTION
## Summary
This PR fixes Instagram link detection to support both `/reel/` and `/reels/` URL formats across all components.

## Problem
The bot only detected Instagram links with `/reel/` (singular), but Instagram also uses `/reels/` (plural) in some URLs:
- ✅ Detected: `https://www.instagram.com/reel/code/`
- ❌ Not detected: `https://www.instagram.com/reels/code/`

## Solution
Updated the Instagram regex patterns from `/reel/` to `/reels?/`

The `s?` makes the "s" optional, matching both `reel` and `reels`.