### PR TITLE
Add Reddit footer-only metadata

### DIFF
--- a/service/src/handlers/reddit.ts
+++ b/service/src/handlers/reddit.ts
@@ -114,6 +114,7 @@ export const redditHandler: PlatformHandler = {
                     video,
                     color: platformColors.reddit,
                     platform: 'reddit',
+                    footerOnlyActivity: true,
                 },
             };
         } catch (error) {

--- a/service/src/index.ts
+++ b/service/src/index.ts
@@ -244,7 +244,7 @@ app.get('/activity/:encodedData', (c) => {
     const accept = c.req.header('Accept') || '';
 
     // Decode the embed data from URL-safe base64
-    let embedData: { t?: string; d?: string; i?: string; v?: string; p?: string; a?: string; h?: string; ic?: string; s?: string; u?: string } = {};
+    let embedData: { t?: string; d?: string; i?: string; v?: string; p?: string; a?: string; h?: string; ic?: string; s?: string; u?: string; fo?: number } = {};
     try {
         // Restore base64 padding and special chars
         let base64 = encodedData.replace(/-/g, '+').replace(/_/g, '/');
@@ -259,8 +259,6 @@ app.get('/activity/:encodedData', (c) => {
 
     // Only respond with ActivityPub JSON if client requests it
     if (accept.includes('application/activity+json') || accept.includes('application/ld+json')) {
-        const authorName = embedData.a || 'FixEmbed';
-
         // Build attachment
         let attachment: any[] = [];
         if (embedData.v) {
@@ -282,7 +280,7 @@ app.get('/activity/:encodedData', (c) => {
             }];
         }
 
-        const activityPubResponse = {
+        const activityPubResponse: Record<string, unknown> = {
             '@context': [
                 'https://www.w3.org/ns/activitystreams',
                 {
@@ -295,11 +293,14 @@ app.get('/activity/:encodedData', (c) => {
             'type': 'Note',
             'summary': embedData.s || null, // Stats row
             'content': `<p>${embedData.d || ''}</p>`,
-            'attributedTo': `https://fixembed.app/activity/${encodedData}/actor`,
             'published': new Date().toISOString(),
             'url': embedData.u || 'https://fixembed.app',
             ...(attachment.length > 0 ? { 'attachment': attachment } : {}),
         };
+
+        if (!embedData.fo) {
+            activityPubResponse.attributedTo = `https://fixembed.app/activity/${encodedData}/actor`;
+        }
 
         return c.json(activityPubResponse, 200, {
             'Content-Type': 'application/activity+json; charset=utf-8',

--- a/service/src/types.ts
+++ b/service/src/types.ts
@@ -47,6 +47,7 @@ export interface EmbedData {
     timestamp?: string;
     platform: Platform;
     stats?: string;
+    footerOnlyActivity?: boolean;
 }
 
 export interface VideoEmbed {

--- a/service/src/utils/embed.ts
+++ b/service/src/utils/embed.ts
@@ -37,6 +37,7 @@ function buildActivityData(embed: EmbedData): string {
         ic: embed.authorAvatar || FIXEMBED_LOGO,
         s: embed.stats,
         u: embed.url,
+        fo: embed.footerOnlyActivity ? 1 : 0,
     };
 
     const json = JSON.stringify(payload);
@@ -45,7 +46,7 @@ function buildActivityData(embed: EmbedData): string {
 }
 
 function shouldExposeActivityPub(embed: EmbedData): boolean {
-    return embed.platform === 'twitter' || embed.platform === 'bluesky' || embed.platform === 'threads';
+    return embed.footerOnlyActivity || embed.platform === 'twitter' || embed.platform === 'bluesky' || embed.platform === 'threads';
 }
 
 /**

--- a/service/tests/run-tests.ts
+++ b/service/tests/run-tests.ts
@@ -176,7 +176,7 @@ const tests: TestCase[] = [
         },
     },
     {
-        name: 'generateEmbedHTML does not expose ActivityPub metadata for Reddit cards',
+        name: 'generateEmbedHTML exposes footer-only ActivityPub metadata for Reddit cards',
         run: () => {
             const html = generateEmbedHTML({
                 title: 'How to change the owner of a pet?',
@@ -188,10 +188,11 @@ const tests: TestCase[] = [
                 image: 'https://cdn.example/reddit-thumb.jpg',
                 color: '#FF4500',
                 platform: 'reddit',
+                footerOnlyActivity: true,
             }, 'Discordbot/2.0');
 
             assert.match(html, /application\/json\+oembed/);
-            assert.doesNotMatch(html, /application\/activity\+json/);
+            assert.match(html, /application\/activity\+json/);
             assert.match(html, /og:title" content="How to change the owner of a pet\?"/);
             assert.match(html, /og:site_name" content="r\/Minecraft"/);
         },


### PR DESCRIPTION
## Summary
- add a footer-only ActivityPub mode for Reddit embeds
- keep the cleaner Reddit card layout from the previous PR
- attempt to restore the FixEmbed footer without reintroducing the fediverse-style actor header

## Expected result
- Reddit cards keep the improved title/body/subreddit layout
- the footer should return
- the `@fixembed@fixembed.app` style author header should stay suppressed because Reddit uses footer-only ActivityPub metadata

## Note
- this is intentionally narrow so we can validate the footer behavior separately
