### PR TITLE
Normalize embed branding across platforms

### DIFF
--- a/service/src/handlers/bilibili.ts
+++ b/service/src/handlers/bilibili.ts
@@ -136,6 +136,7 @@ export const bilibiliHandler: PlatformHandler = {
                         url: canonicalUrl,
                         siteName: getBrandedSiteName('bilibili'),
                         authorName: scrapeResult.author || undefined, // Don't set if no author found
+                        authorHandle: scrapeResult.author ? `@${scrapeResult.author}` : undefined,
                         image: imageUrl,
                         video: scrapeResult.video ? {
                             url: `https://${embedDomain}/proxy/bilibili?url=${encodeURIComponent(scrapeResult.video)}`,

--- a/service/src/handlers/instagram.ts
+++ b/service/src/handlers/instagram.ts
@@ -377,11 +377,14 @@ export const instagramHandler: PlatformHandler = {
                 return {
                     success: true,
                     data: {
-                        title: authorName || 'Post',
+                        title: authorName || (parsed.type === 'reel' ? 'Instagram Reel' : 'Instagram Post'),
                         description: desc ? truncateText(desc, 280) : '',
                         url: canonicalUrl,
                         siteName: getBrandedSiteName('instagram'),
-                        // authorName: authorName, // OLD: Don't set author field to avoid duplication
+                        authorName,
+                        authorHandle: authorName?.match(/\(@([^\)]+)\)/)?.[1]
+                            ? `@${authorName.match(/\(@([^\)]+)\)/)![1]}`
+                            : (authorName?.startsWith('@') ? authorName : undefined),
                         image: vxResult.image, // This is the composite carousel image from vxinstagram
                         color: platformColors.instagram,
                         platform: 'instagram',
@@ -431,7 +434,7 @@ export const instagramHandler: PlatformHandler = {
             const result: HandlerResponse = {
                 success: true,
                 data: {
-                    title: parsed.type === 'reel' ? 'Reel' : 'Post',
+                    title: parsed.type === 'reel' ? 'Instagram Reel' : 'Instagram Post',
                     description: description
                         ? truncateText(description, 280)
                         : '',
@@ -505,8 +508,12 @@ export const instagramHandler: PlatformHandler = {
                     }
 
                     if (authorName) {
-                        // result.data!.authorName = authorName; // Don't set author field to avoid duplication
-                        result.data!.title = authorName; // User requested: Author Name as Title
+                        result.data!.authorName = authorName;
+                        const handleMatch = authorName.match(/\(@([^\)]+)\)/);
+                        result.data!.authorHandle = handleMatch
+                            ? `@${handleMatch[1]}`
+                            : (authorName.startsWith('@') ? authorName : undefined);
+                        result.data!.title = authorName;
                     }
 
                     // Update description if we have a better one
@@ -520,9 +527,8 @@ export const instagramHandler: PlatformHandler = {
             }
 
             // Fallback: If we still have generic title but have authorName (e.g. from existing logic), set it
-            if ((result.data!.title === 'Post' || result.data!.title === 'Reel') && result.data!.authorName) {
+            if ((result.data!.title === 'Instagram Post' || result.data!.title === 'Instagram Reel') && result.data!.authorName) {
                 result.data!.title = result.data!.authorName;
-                result.data!.authorName = undefined; // Clear author field to avoid duplication
             }
             // Clean description: Remove author name if it appears at the start
             // This happens often (e.g. "username Caption text")

--- a/service/src/handlers/pixiv.ts
+++ b/service/src/handlers/pixiv.ts
@@ -103,6 +103,7 @@ export const pixivHandler: PlatformHandler = {
                         url: canonicalUrl,
                         siteName: getBrandedSiteName('pixiv'),
                         authorName: scrapeResult.author,
+                        authorHandle: scrapeResult.author ? `@${scrapeResult.author}` : undefined,
                         authorUrl: scrapeResult.author ? `https://www.pixiv.net/users/${scrapeResult.author}` : undefined,
                         image: scrapeResult.image,
                         color: platformColors.pixiv,

--- a/service/src/handlers/youtube.ts
+++ b/service/src/handlers/youtube.ts
@@ -1,20 +1,14 @@
 /**
  * FixEmbed Service - YouTube Handler
- * 
- * Uses Invidious API to fetch video metadata AND direct stream URLs.
+ *
+ * Uses Invidious API to fetch video metadata and direct stream URLs.
  * Based on koutube implementation (https://github.com/iGerman00/koutube)
- * 
- * Key features:
- * - Fetches from Invidious API instances for metadata
- * - Gets direct video stream URLs for inline playback
- * - Falls back to oEmbed if Invidious fails
  */
 
 import type { Env, HandlerResponse, PlatformHandler } from '../types.ts';
 import { parseYouTubeUrl, truncateText } from '../utils/fetch.ts';
-import { platformColors } from '../utils/embed.ts';
+import { formatStats, getBrandedSiteName, platformColors } from '../utils/embed.ts';
 
-// Invidious API instances
 const INVIDIOUS_INSTANCES = [
     'https://invidious.io.lol',
     'https://iv.nboeck.de',
@@ -26,7 +20,6 @@ function getRandomInstance(): string {
     return INVIDIOUS_INSTANCES[Math.floor(Math.random() * INVIDIOUS_INSTANCES.length)];
 }
 
-// Invidious video response types
 interface FormatStream {
     url: string;
     itag: string;
@@ -67,17 +60,6 @@ interface YouTubeOEmbed {
     thumbnail_url: string;
 }
 
-// Format large numbers
-function formatNumber(num: number): string {
-    if (num >= 1_000_000) {
-        return (num / 1_000_000).toFixed(1) + 'M';
-    } else if (num >= 1_000) {
-        return (num / 1_000).toFixed(1) + 'K';
-    }
-    return num.toLocaleString();
-}
-
-// Format duration
 function formatDuration(seconds: number): string {
     const hours = Math.floor(seconds / 3600);
     const minutes = Math.floor((seconds % 3600) / 60);
@@ -107,9 +89,8 @@ export const youtubeHandler: PlatformHandler = {
 
         const videoId = parsed.videoId;
         const videoUrl = `https://www.youtube.com/watch?v=${videoId}`;
-        const embedDomain = (env as any).EMBED_DOMAIN || 'embed.ken.tools';
+        const embedDomain = (env as any).EMBED_DOMAIN || 'fixembed.app';
 
-        // Try Invidious API for full video data
         for (let attempt = 0; attempt < 3; attempt++) {
             const instance = getRandomInstance();
 
@@ -117,7 +98,7 @@ export const youtubeHandler: PlatformHandler = {
                 const apiUrl = `${instance}/api/v1/videos/${videoId}?fields=title,videoId,description,publishedText,viewCount,likeCount,author,authorId,authorUrl,lengthSeconds,videoThumbnails,formatStreams,liveNow`;
                 const response = await fetch(apiUrl, {
                     headers: {
-                        'Accept': 'application/json',
+                        Accept: 'application/json',
                     },
                 });
 
@@ -133,30 +114,25 @@ export const youtubeHandler: PlatformHandler = {
                     continue;
                 }
 
-                // Get best thumbnail
                 let thumbnail = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
                 if (data.videoThumbnails && data.videoThumbnails.length > 0) {
-                    const maxres = data.videoThumbnails.find(t => t.quality === 'maxres');
-                    const hq = data.videoThumbnails.find(t => t.quality === 'high' || t.quality === 'hq720');
+                    const maxres = data.videoThumbnails.find((t) => t.quality === 'maxres');
+                    const hq = data.videoThumbnails.find((t) => t.quality === 'high' || t.quality === 'hq720');
                     thumbnail = (maxres || hq || data.videoThumbnails[0]).url;
                 }
 
-                // Get best video stream (prefer 720p or 360p for compatibility)
                 let videoStreamUrl: string | undefined;
                 let videoWidth = 1280;
                 let videoHeight = 720;
 
                 if (data.formatStreams && data.formatStreams.length > 0 && !data.liveNow) {
-                    // Prefer 720p (itag 22), then 360p (itag 18)
-                    const hd = data.formatStreams.find(f => f.itag === '22');
-                    const sd = data.formatStreams.find(f => f.itag === '18');
+                    const hd = data.formatStreams.find((f) => f.itag === '22');
+                    const sd = data.formatStreams.find((f) => f.itag === '18');
                     const stream = hd || sd || data.formatStreams[0];
 
                     if (stream && stream.url) {
-                        // Proxy the video through our domain
                         videoStreamUrl = `https://${embedDomain}/proxy/youtube?url=${encodeURIComponent(stream.url)}`;
 
-                        // Parse resolution
                         if (stream.resolution) {
                             const [w, h] = stream.resolution.split('x').map(Number);
                             if (w && h) {
@@ -167,23 +143,16 @@ export const youtubeHandler: PlatformHandler = {
                     }
                 }
 
-                // Build stats string
-                const stats: string[] = [];
-                stats.push(`👁️ ${formatNumber(data.viewCount)}`);
-                if (data.likeCount) {
-                    stats.push(`👍 ${formatNumber(data.likeCount)}`);
-                }
-                const statsStr = stats.join(' • ');
+                const stats = formatStats({
+                    views: data.viewCount,
+                    likes: data.likeCount,
+                });
 
-                // Format duration
                 const duration = formatDuration(data.lengthSeconds);
-
-                // Build description
                 let description = data.description || '';
                 if (description.length > 150) {
                     description = truncateText(description, 150);
                 }
-                description = description ? `${description}\n\n${statsStr}` : statsStr;
 
                 return {
                     success: true,
@@ -191,7 +160,7 @@ export const youtubeHandler: PlatformHandler = {
                         title: data.title,
                         description,
                         url: videoUrl,
-                        siteName: `YouTube • ${duration}`,
+                        siteName: getBrandedSiteName('youtube', duration),
                         authorName: data.author,
                         authorUrl: `https://www.youtube.com${data.authorUrl}`,
                         image: thumbnail,
@@ -203,6 +172,7 @@ export const youtubeHandler: PlatformHandler = {
                         } : undefined,
                         color: platformColors.youtube,
                         platform: 'youtube',
+                        stats,
                     },
                 };
             } catch (error) {
@@ -211,7 +181,6 @@ export const youtubeHandler: PlatformHandler = {
             }
         }
 
-        // Fallback: Use YouTube's oEmbed API
         console.log('All Invidious instances failed, falling back to oEmbed');
         try {
             const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(videoUrl)}&format=json`;
@@ -223,9 +192,9 @@ export const youtubeHandler: PlatformHandler = {
                     success: true,
                     data: {
                         title: data.title,
-                        description: `by ${data.author_name}`,
+                        description: '',
                         url: videoUrl,
-                        siteName: 'YouTube',
+                        siteName: getBrandedSiteName('youtube'),
                         authorName: data.author_name,
                         authorUrl: data.author_url,
                         image: data.thumbnail_url || `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
@@ -238,14 +207,13 @@ export const youtubeHandler: PlatformHandler = {
             console.error('oEmbed fallback error:', error);
         }
 
-        // Final fallback
         return {
             success: true,
             data: {
                 title: 'YouTube Video',
                 description: 'Watch on YouTube',
                 url: videoUrl,
-                siteName: 'YouTube',
+                siteName: getBrandedSiteName('youtube'),
                 image: `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
                 color: platformColors.youtube,
                 platform: 'youtube',

--- a/service/src/utils/embed.ts
+++ b/service/src/utils/embed.ts
@@ -186,6 +186,7 @@ export const platformColors: Record<string, string> = {
     threads: '#000000',
     pixiv: '#0096FA',
     bluesky: '#1185FE',
+    youtube: '#FF0000',
     bilibili: '#00A1D6',
 };
 

--- a/service/tests/run-tests.ts
+++ b/service/tests/run-tests.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { findHandler } from '../src/handlers/index.ts';
 import { twitterHandler } from '../src/handlers/twitter.ts';
 import type { Env } from '../src/types.ts';
-import { formatStats, generateEmbedHTML, getBrandedSiteName } from '../src/utils/embed.ts';
+import { formatStats, generateEmbedHTML, getBrandedSiteName, platformColors } from '../src/utils/embed.ts';
 import {
     cleanUrl,
     parseBlueskyUrl,
@@ -195,6 +195,12 @@ const tests: TestCase[] = [
             assert.match(html, /application\/activity\+json/);
             assert.match(html, /og:title" content="How to change the owner of a pet\?"/);
             assert.match(html, /og:site_name" content="r\/Minecraft"/);
+        },
+    },
+    {
+        name: 'platformColors includes YouTube branding color',
+        run: () => {
+            assert.equal(platformColors.youtube, '#FF0000');
         },
     },
 ];


### PR DESCRIPTION
## Summary
- normalize embed branding metadata across the platforms we control
- align YouTube with the shared FixEmbed provider naming, color, and stats patterns
- make Instagram metadata less path-dependent by preserving author metadata more consistently
- add author handle metadata for Pixiv and Bilibili when available

## Verification
- ran `npm test` in `service`
- 13/13 tests passed

## Notes
- Twitter/X still redirects to FxTwitter, so it remains outside the native FixEmbed branding system for now
