### PR TITLE
Revert PRs #34 through #31

### DIFF
--- a/service/src/handlers/bilibili.ts
+++ b/service/src/handlers/bilibili.ts
@@ -136,7 +136,6 @@ export const bilibiliHandler: PlatformHandler = {
                         url: canonicalUrl,
                         siteName: getBrandedSiteName('bilibili'),
                         authorName: scrapeResult.author || undefined, // Don't set if no author found
-                        authorHandle: scrapeResult.author ? `@${scrapeResult.author}` : undefined,
                         image: imageUrl,
                         video: scrapeResult.video ? {
                             url: `https://${embedDomain}/proxy/bilibili?url=${encodeURIComponent(scrapeResult.video)}`,

--- a/service/src/handlers/bluesky.ts
+++ b/service/src/handlers/bluesky.ts
@@ -115,14 +115,14 @@ export const blueskyHandler: PlatformHandler = {
             return {
                 success: true,
                 data: {
-                    title: author.displayName
-                        ? `${author.displayName} (@${author.handle})`
-                        : `@${author.handle}`,
-                    description,
+                    // Title is the post content (or handle if empty)
+                    title: description || `@${author.handle}`,
+                    // Description shows the full post if title was truncated
+                    description: '',
                     url: `https://bsky.app/profile/${author.handle}/post/${parsed.postId}`,
                     siteName: getBrandedSiteName('bluesky'),
+                    // authorName shows handle - don't duplicate display name
                     authorName: `@${author.handle}`,
-                    authorHandle: `@${author.handle}`,
                     authorUrl: `https://bsky.app/profile/${author.handle}`,
                     authorAvatar: author.avatar,
                     image,

--- a/service/src/handlers/instagram.ts
+++ b/service/src/handlers/instagram.ts
@@ -377,14 +377,11 @@ export const instagramHandler: PlatformHandler = {
                 return {
                     success: true,
                     data: {
-                        title: authorName || (parsed.type === 'reel' ? 'Instagram Reel' : 'Instagram Post'),
+                        title: authorName || 'Post',
                         description: desc ? truncateText(desc, 280) : '',
                         url: canonicalUrl,
                         siteName: getBrandedSiteName('instagram'),
-                        authorName,
-                        authorHandle: authorName?.match(/\(@([^\)]+)\)/)?.[1]
-                            ? `@${authorName.match(/\(@([^\)]+)\)/)![1]}`
-                            : (authorName?.startsWith('@') ? authorName : undefined),
+                        // authorName: authorName, // OLD: Don't set author field to avoid duplication
                         image: vxResult.image, // This is the composite carousel image from vxinstagram
                         color: platformColors.instagram,
                         platform: 'instagram',
@@ -434,7 +431,7 @@ export const instagramHandler: PlatformHandler = {
             const result: HandlerResponse = {
                 success: true,
                 data: {
-                    title: parsed.type === 'reel' ? 'Instagram Reel' : 'Instagram Post',
+                    title: parsed.type === 'reel' ? 'Reel' : 'Post',
                     description: description
                         ? truncateText(description, 280)
                         : '',
@@ -508,12 +505,8 @@ export const instagramHandler: PlatformHandler = {
                     }
 
                     if (authorName) {
-                        result.data!.authorName = authorName;
-                        const handleMatch = authorName.match(/\(@([^\)]+)\)/);
-                        result.data!.authorHandle = handleMatch
-                            ? `@${handleMatch[1]}`
-                            : (authorName.startsWith('@') ? authorName : undefined);
-                        result.data!.title = authorName;
+                        // result.data!.authorName = authorName; // Don't set author field to avoid duplication
+                        result.data!.title = authorName; // User requested: Author Name as Title
                     }
 
                     // Update description if we have a better one
@@ -527,8 +520,9 @@ export const instagramHandler: PlatformHandler = {
             }
 
             // Fallback: If we still have generic title but have authorName (e.g. from existing logic), set it
-            if ((result.data!.title === 'Instagram Post' || result.data!.title === 'Instagram Reel') && result.data!.authorName) {
+            if ((result.data!.title === 'Post' || result.data!.title === 'Reel') && result.data!.authorName) {
                 result.data!.title = result.data!.authorName;
+                result.data!.authorName = undefined; // Clear author field to avoid duplication
             }
             // Clean description: Remove author name if it appears at the start
             // This happens often (e.g. "username Caption text")

--- a/service/src/handlers/pixiv.ts
+++ b/service/src/handlers/pixiv.ts
@@ -103,7 +103,6 @@ export const pixivHandler: PlatformHandler = {
                         url: canonicalUrl,
                         siteName: getBrandedSiteName('pixiv'),
                         authorName: scrapeResult.author,
-                        authorHandle: scrapeResult.author ? `@${scrapeResult.author}` : undefined,
                         authorUrl: scrapeResult.author ? `https://www.pixiv.net/users/${scrapeResult.author}` : undefined,
                         image: scrapeResult.image,
                         color: platformColors.pixiv,

--- a/service/src/handlers/reddit.ts
+++ b/service/src/handlers/reddit.ts
@@ -4,7 +4,7 @@
 
 import type { Env, HandlerResponse, PlatformHandler } from '../types.ts';
 import { parseRedditUrl, fetchJSON, truncateText } from '../utils/fetch.ts';
-import { platformColors } from '../utils/embed.ts';
+import { platformColors, getBrandedSiteName, formatStats } from '../utils/embed.ts';
 
 interface RedditPost {
     title: string;
@@ -56,17 +56,20 @@ export const redditHandler: PlatformHandler = {
         const parsed = parseRedditUrl(url);
 
         if (!parsed) {
+            // Try short URL format
             const shortMatch = url.match(/redd\.it\/([^\/\?]+)/i);
             if (!shortMatch) {
                 return { success: false, error: 'Invalid Reddit URL' };
             }
+            // Redirect short URLs
             return {
                 success: false,
-                redirect: `https://reddit.com/comments/${shortMatch[1]}`,
+                redirect: `https://reddit.com/comments/${shortMatch[1]}`
             };
         }
 
         try {
+            // Fetch post data using Reddit's JSON API
             const apiUrl = `https://www.reddit.com/r/${parsed.subreddit}/comments/${parsed.postId}.json`;
 
             const response = await fetchJSON<Array<{ data: { children: Array<{ data: RedditPost }> } }>>(apiUrl, {
@@ -80,11 +83,23 @@ export const redditHandler: PlatformHandler = {
             }
 
             const post = response[0].data.children[0].data;
-            const description = post.selftext ? truncateText(post.selftext, 280) : '';
 
+            // Build description (no stats here - moved to oEmbed row)
+            const description = post.selftext
+                ? truncateText(post.selftext, 280)
+                : post.title;
+
+            // Format stats for oEmbed row (consistent with Twitter/Threads/Bluesky)
+            const stats = formatStats({
+                comments: post.num_comments,
+                likes: post.score, // Reddit uses score/upvotes as "likes"
+            });
+
+            // Check for media
             let image: string | undefined;
             let video: { url: string; width: number; height: number; thumbnail?: string } | undefined;
 
+            // Video content
             const redditVideo = post.secure_media?.reddit_video || post.media?.reddit_video;
             if (post.is_video && redditVideo) {
                 video = {
@@ -93,27 +108,32 @@ export const redditHandler: PlatformHandler = {
                     height: redditVideo.height,
                     thumbnail: post.thumbnail !== 'self' ? post.thumbnail : undefined,
                 };
-            } else if (post.preview?.images?.[0]) {
+            }
+            // Image content
+            else if (post.preview?.images?.[0]) {
                 const imageSource = post.preview.images[0].source;
+                // Reddit HTML-encodes URLs in the API response
                 image = imageSource.url.replace(/&amp;/g, '&');
-            } else if (post.url.match(/\.(jpg|jpeg|png|gif|webp)$/i)) {
+            }
+            // External image link
+            else if (post.url.match(/\.(jpg|jpeg|png|gif|webp)$/i)) {
                 image = post.url;
             }
 
             return {
                 success: true,
                 data: {
-                    title: truncateText(post.title, 140),
+                    title: `r/${post.subreddit} • ${truncateText(post.title, 100)}`,
                     description,
                     url: `https://reddit.com${post.permalink}`,
-                    siteName: `r/${post.subreddit}`,
-                    authorName: `Posted by u/${post.author}`,
-                    authorHandle: `u/${post.author}`,
+                    siteName: getBrandedSiteName('reddit'),
+                    authorName: `u/${post.author}`,
                     authorUrl: `https://reddit.com/u/${post.author}`,
                     image,
                     video,
                     color: platformColors.reddit,
                     platform: 'reddit',
+                    stats, // Consistent stats via oEmbed like other platforms
                 },
             };
         } catch (error) {

--- a/service/src/handlers/reddit.ts
+++ b/service/src/handlers/reddit.ts
@@ -114,7 +114,6 @@ export const redditHandler: PlatformHandler = {
                     video,
                     color: platformColors.reddit,
                     platform: 'reddit',
-                    footerOnlyActivity: true,
                 },
             };
         } catch (error) {

--- a/service/src/handlers/threads.ts
+++ b/service/src/handlers/threads.ts
@@ -245,12 +245,11 @@ export const threadsHandler: PlatformHandler = {
                 const result: HandlerResponse = {
                     success: true,
                     data: {
-                        title: `@${displayUsername}`,
-                        description,
+                        title: description || 'Thread',
+                        description: '', // Stats go via oEmbed, not in description
                         url: normalizedUrl,
                         siteName: getBrandedSiteName('threads'),
                         authorName: `@${displayUsername}`,
-                        authorHandle: `@${displayUsername}`,
                         authorUrl: `https://threads.net/@${displayUsername}`,
                         color: platformColors.threads,
                         platform: 'threads',
@@ -304,12 +303,11 @@ export const threadsHandler: PlatformHandler = {
                     return {
                         success: true,
                         data: {
-                            title: `@${data.author_name || username}`,
+                            title: data.title ? truncateText(data.title, 100) : 'Thread',
                             description: data.title ? truncateText(data.title, 280) : '',
                             url: normalizedUrl,
                             siteName: getBrandedSiteName('threads'),
                             authorName: `@${data.author_name || username}`,
-                            authorHandle: `@${data.author_name || username}`,
                             authorUrl: `https://threads.net/@${username}`,
                             image: data.thumbnail_url,
                             color: platformColors.threads,
@@ -330,7 +328,6 @@ export const threadsHandler: PlatformHandler = {
                     url: normalizedUrl,
                     siteName: getBrandedSiteName('threads'),
                     authorName: `@${username}`,
-                    authorHandle: `@${username}`,
                     authorUrl: `https://threads.net/@${username}`,
                     color: platformColors.threads,
                     platform: 'threads',

--- a/service/src/handlers/youtube.ts
+++ b/service/src/handlers/youtube.ts
@@ -1,14 +1,20 @@
 /**
  * FixEmbed Service - YouTube Handler
- *
- * Uses Invidious API to fetch video metadata and direct stream URLs.
+ * 
+ * Uses Invidious API to fetch video metadata AND direct stream URLs.
  * Based on koutube implementation (https://github.com/iGerman00/koutube)
+ * 
+ * Key features:
+ * - Fetches from Invidious API instances for metadata
+ * - Gets direct video stream URLs for inline playback
+ * - Falls back to oEmbed if Invidious fails
  */
 
 import type { Env, HandlerResponse, PlatformHandler } from '../types.ts';
 import { parseYouTubeUrl, truncateText } from '../utils/fetch.ts';
-import { formatStats, getBrandedSiteName, platformColors } from '../utils/embed.ts';
+import { platformColors } from '../utils/embed.ts';
 
+// Invidious API instances
 const INVIDIOUS_INSTANCES = [
     'https://invidious.io.lol',
     'https://iv.nboeck.de',
@@ -20,6 +26,7 @@ function getRandomInstance(): string {
     return INVIDIOUS_INSTANCES[Math.floor(Math.random() * INVIDIOUS_INSTANCES.length)];
 }
 
+// Invidious video response types
 interface FormatStream {
     url: string;
     itag: string;
@@ -60,6 +67,17 @@ interface YouTubeOEmbed {
     thumbnail_url: string;
 }
 
+// Format large numbers
+function formatNumber(num: number): string {
+    if (num >= 1_000_000) {
+        return (num / 1_000_000).toFixed(1) + 'M';
+    } else if (num >= 1_000) {
+        return (num / 1_000).toFixed(1) + 'K';
+    }
+    return num.toLocaleString();
+}
+
+// Format duration
 function formatDuration(seconds: number): string {
     const hours = Math.floor(seconds / 3600);
     const minutes = Math.floor((seconds % 3600) / 60);
@@ -89,8 +107,9 @@ export const youtubeHandler: PlatformHandler = {
 
         const videoId = parsed.videoId;
         const videoUrl = `https://www.youtube.com/watch?v=${videoId}`;
-        const embedDomain = (env as any).EMBED_DOMAIN || 'fixembed.app';
+        const embedDomain = (env as any).EMBED_DOMAIN || 'embed.ken.tools';
 
+        // Try Invidious API for full video data
         for (let attempt = 0; attempt < 3; attempt++) {
             const instance = getRandomInstance();
 
@@ -98,7 +117,7 @@ export const youtubeHandler: PlatformHandler = {
                 const apiUrl = `${instance}/api/v1/videos/${videoId}?fields=title,videoId,description,publishedText,viewCount,likeCount,author,authorId,authorUrl,lengthSeconds,videoThumbnails,formatStreams,liveNow`;
                 const response = await fetch(apiUrl, {
                     headers: {
-                        Accept: 'application/json',
+                        'Accept': 'application/json',
                     },
                 });
 
@@ -114,25 +133,30 @@ export const youtubeHandler: PlatformHandler = {
                     continue;
                 }
 
+                // Get best thumbnail
                 let thumbnail = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
                 if (data.videoThumbnails && data.videoThumbnails.length > 0) {
-                    const maxres = data.videoThumbnails.find((t) => t.quality === 'maxres');
-                    const hq = data.videoThumbnails.find((t) => t.quality === 'high' || t.quality === 'hq720');
+                    const maxres = data.videoThumbnails.find(t => t.quality === 'maxres');
+                    const hq = data.videoThumbnails.find(t => t.quality === 'high' || t.quality === 'hq720');
                     thumbnail = (maxres || hq || data.videoThumbnails[0]).url;
                 }
 
+                // Get best video stream (prefer 720p or 360p for compatibility)
                 let videoStreamUrl: string | undefined;
                 let videoWidth = 1280;
                 let videoHeight = 720;
 
                 if (data.formatStreams && data.formatStreams.length > 0 && !data.liveNow) {
-                    const hd = data.formatStreams.find((f) => f.itag === '22');
-                    const sd = data.formatStreams.find((f) => f.itag === '18');
+                    // Prefer 720p (itag 22), then 360p (itag 18)
+                    const hd = data.formatStreams.find(f => f.itag === '22');
+                    const sd = data.formatStreams.find(f => f.itag === '18');
                     const stream = hd || sd || data.formatStreams[0];
 
                     if (stream && stream.url) {
+                        // Proxy the video through our domain
                         videoStreamUrl = `https://${embedDomain}/proxy/youtube?url=${encodeURIComponent(stream.url)}`;
 
+                        // Parse resolution
                         if (stream.resolution) {
                             const [w, h] = stream.resolution.split('x').map(Number);
                             if (w && h) {
@@ -143,16 +167,23 @@ export const youtubeHandler: PlatformHandler = {
                     }
                 }
 
-                const stats = formatStats({
-                    views: data.viewCount,
-                    likes: data.likeCount,
-                });
+                // Build stats string
+                const stats: string[] = [];
+                stats.push(`👁️ ${formatNumber(data.viewCount)}`);
+                if (data.likeCount) {
+                    stats.push(`👍 ${formatNumber(data.likeCount)}`);
+                }
+                const statsStr = stats.join(' • ');
 
+                // Format duration
                 const duration = formatDuration(data.lengthSeconds);
+
+                // Build description
                 let description = data.description || '';
                 if (description.length > 150) {
                     description = truncateText(description, 150);
                 }
+                description = description ? `${description}\n\n${statsStr}` : statsStr;
 
                 return {
                     success: true,
@@ -160,7 +191,7 @@ export const youtubeHandler: PlatformHandler = {
                         title: data.title,
                         description,
                         url: videoUrl,
-                        siteName: getBrandedSiteName('youtube', duration),
+                        siteName: `YouTube • ${duration}`,
                         authorName: data.author,
                         authorUrl: `https://www.youtube.com${data.authorUrl}`,
                         image: thumbnail,
@@ -172,7 +203,6 @@ export const youtubeHandler: PlatformHandler = {
                         } : undefined,
                         color: platformColors.youtube,
                         platform: 'youtube',
-                        stats,
                     },
                 };
             } catch (error) {
@@ -181,6 +211,7 @@ export const youtubeHandler: PlatformHandler = {
             }
         }
 
+        // Fallback: Use YouTube's oEmbed API
         console.log('All Invidious instances failed, falling back to oEmbed');
         try {
             const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(videoUrl)}&format=json`;
@@ -192,9 +223,9 @@ export const youtubeHandler: PlatformHandler = {
                     success: true,
                     data: {
                         title: data.title,
-                        description: '',
+                        description: `by ${data.author_name}`,
                         url: videoUrl,
-                        siteName: getBrandedSiteName('youtube'),
+                        siteName: 'YouTube',
                         authorName: data.author_name,
                         authorUrl: data.author_url,
                         image: data.thumbnail_url || `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
@@ -207,13 +238,14 @@ export const youtubeHandler: PlatformHandler = {
             console.error('oEmbed fallback error:', error);
         }
 
+        // Final fallback
         return {
             success: true,
             data: {
                 title: 'YouTube Video',
                 description: 'Watch on YouTube',
                 url: videoUrl,
-                siteName: getBrandedSiteName('youtube'),
+                siteName: 'YouTube',
                 image: `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
                 color: platformColors.youtube,
                 platform: 'youtube',

--- a/service/src/index.ts
+++ b/service/src/index.ts
@@ -244,7 +244,7 @@ app.get('/activity/:encodedData', (c) => {
     const accept = c.req.header('Accept') || '';
 
     // Decode the embed data from URL-safe base64
-    let embedData: { t?: string; d?: string; i?: string; v?: string; p?: string; a?: string; h?: string; ic?: string; s?: string; u?: string; fo?: number } = {};
+    let embedData: { t?: string; d?: string; i?: string; v?: string; p?: string; a?: string; h?: string; ic?: string; s?: string; u?: string } = {};
     try {
         // Restore base64 padding and special chars
         let base64 = encodedData.replace(/-/g, '+').replace(/_/g, '/');
@@ -259,6 +259,8 @@ app.get('/activity/:encodedData', (c) => {
 
     // Only respond with ActivityPub JSON if client requests it
     if (accept.includes('application/activity+json') || accept.includes('application/ld+json')) {
+        const authorName = embedData.a || 'FixEmbed';
+
         // Build attachment
         let attachment: any[] = [];
         if (embedData.v) {
@@ -280,7 +282,7 @@ app.get('/activity/:encodedData', (c) => {
             }];
         }
 
-        const activityPubResponse: Record<string, unknown> = {
+        const activityPubResponse = {
             '@context': [
                 'https://www.w3.org/ns/activitystreams',
                 {
@@ -293,14 +295,11 @@ app.get('/activity/:encodedData', (c) => {
             'type': 'Note',
             'summary': embedData.s || null, // Stats row
             'content': `<p>${embedData.d || ''}</p>`,
+            'attributedTo': `https://fixembed.app/activity/${encodedData}/actor`,
             'published': new Date().toISOString(),
             'url': embedData.u || 'https://fixembed.app',
             ...(attachment.length > 0 ? { 'attachment': attachment } : {}),
         };
-
-        if (!embedData.fo) {
-            activityPubResponse.attributedTo = `https://fixembed.app/activity/${encodedData}/actor`;
-        }
 
         return c.json(activityPubResponse, 200, {
             'Content-Type': 'application/activity+json; charset=utf-8',

--- a/service/src/types.ts
+++ b/service/src/types.ts
@@ -47,7 +47,6 @@ export interface EmbedData {
     timestamp?: string;
     platform: Platform;
     stats?: string;
-    footerOnlyActivity?: boolean;
 }
 
 export interface VideoEmbed {

--- a/service/src/utils/embed.ts
+++ b/service/src/utils/embed.ts
@@ -9,136 +9,108 @@ import type { EmbedData } from '../types.ts';
  */
 export const FIXEMBED_LOGO = 'https://raw.githubusercontent.com/kenhendricks00/FixEmbed/main/assets/logo.png';
 
-function escapeHtml(value: string): string {
-    return value
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;');
-}
-
-function truncateMeta(value: string, maxLength: number): string {
-    if (value.length <= maxLength) {
-        return value;
-    }
-
-    return `${value.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
-}
-
-function buildActivityData(embed: EmbedData): string {
-    const payload = {
-        t: truncateMeta(embed.title, 300),
-        d: truncateMeta(embed.description, 1000),
-        i: embed.images?.[0] || embed.image,
-        v: embed.video?.url,
-        p: embed.siteName,
-        a: embed.authorName,
-        h: embed.authorHandle,
-        ic: embed.authorAvatar || FIXEMBED_LOGO,
-        s: embed.stats,
-        u: embed.url,
-    };
-
-    const json = JSON.stringify(payload);
-    const encoded = btoa(unescape(encodeURIComponent(json)));
-    return encoded.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
-}
-
 /**
  * Generate Open Graph meta tags for Discord/Telegram embeds
  */
 export function generateEmbedHTML(embed: EmbedData, userAgent: string): string {
     const isDiscord = userAgent.toLowerCase().includes('discord');
     const isTelegram = userAgent.toLowerCase().includes('telegram');
-    const escape = escapeHtml;
-    const metaTitle = truncateMeta(embed.title || embed.authorName || 'FixEmbed', 300);
-    const metaDescription = truncateMeta(
-        embed.description || embed.title || embed.authorName || embed.siteName,
-        1000,
-    );
-    const activityUrl = `https://fixembed.app/activity/${buildActivityData(embed)}`;
+
+    // Escape HTML entities
+    const escape = (str: string) =>
+        str.replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
 
     let html = `<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="${escape(metaDescription)}">
-  <meta property="og:title" content="${escape(metaTitle)}">
-  <meta property="og:description" content="${escape(metaDescription)}">
+  <meta property="og:title" content="${escape(embed.title)}">
+  <meta property="og:description" content="${escape(embed.description)}">
   <meta property="og:url" content="${escape(embed.url)}">
   <meta property="og:site_name" content="${escape(embed.siteName)}">
   <meta property="og:type" content="${embed.video ? 'video.other' : 'website'}">
 `;
 
+    // Color theme
     if (embed.color) {
         html += `  <meta name="theme-color" content="${embed.color}">\n`;
     }
 
+    // Author info
     if (embed.authorName) {
         html += `  <meta property="og:article:author" content="${escape(embed.authorName)}">\n`;
     }
 
+    // Image embed - support single image or carousel
     if (embed.images && embed.images.length > 0) {
+        // Multiple images (carousel) - output all og:image tags
         for (const imgUrl of embed.images) {
             html += `  <meta property="og:image" content="${escape(imgUrl)}">\n`;
         }
-        html += `  <meta property="og:image:alt" content="${escape(metaTitle)}">\n`;
+        // Only set card to summary_large_image if NOT a video
         if (!embed.video) {
             html += `  <meta name="twitter:card" content="summary_large_image">\n`;
         }
         html += `  <meta name="twitter:image" content="${escape(embed.images[0])}">\n`;
-        html += `  <meta name="twitter:image:alt" content="${escape(metaTitle)}">\n`;
     } else if (embed.image) {
         html += `  <meta property="og:image" content="${escape(embed.image)}">\n`;
-        html += `  <meta property="og:image:alt" content="${escape(metaTitle)}">\n`;
+        // Only set card to summary_large_image if NOT a video
         if (!embed.video) {
             html += `  <meta name="twitter:card" content="summary_large_image">\n`;
         }
         html += `  <meta name="twitter:image" content="${escape(embed.image)}">\n`;
-        html += `  <meta name="twitter:image:alt" content="${escape(metaTitle)}">\n`;
     }
 
+    // Video embed
     if (embed.video) {
         html += `  <meta property="og:video" content="${escape(embed.video.url)}">\n`;
         html += `  <meta property="og:video:url" content="${escape(embed.video.url)}">\n`;
         html += `  <meta property="og:video:secure_url" content="${escape(embed.video.url)}">\n`;
         html += `  <meta property="og:video:type" content="video/mp4">\n`;
-        html += `  <meta property="og:video:width" content="${embed.video.width}">\n`;
-        html += `  <meta property="og:video:height" content="${embed.video.height}">\n`;
 
         if (embed.video.thumbnail) {
             html += `  <meta property="og:image" content="${escape(embed.video.thumbnail)}">\n`;
-            html += `  <meta property="og:image:alt" content="${escape(metaTitle)}">\n`;
-            html += `  <meta name="twitter:image" content="${escape(embed.video.thumbnail)}">\n`;
-            html += `  <meta name="twitter:image:alt" content="${escape(metaTitle)}">\n`;
         }
 
+        // Use summary_large_image to assume "Rich Embed" layout (text + media)
+        // Discord should still pick up og:video for playback
         html += `  <meta name="twitter:card" content="summary_large_image">\n`;
+
+        // Ensure twitter:image is set for the card validation
+        if (embed.video.thumbnail) {
+            html += `  <meta name="twitter:image" content="${escape(embed.video.thumbnail)}">\n`;
+        }
     } else {
         html += `  <meta name="twitter:card" content="summary_large_image">\n`;
     }
 
-    html += `  <meta name="twitter:title" content="${escape(metaTitle)}">\n`;
-    html += `  <meta name="twitter:description" content="${escape(metaDescription)}">\n`;
+    // Twitter-specific tags
+    html += `  <meta name="twitter:title" content="${escape(embed.title)}">\n`;
+    html += `  <meta name="twitter:description" content="${escape(embed.description)}">\n`;
+
+    // FixEmbed branding - multiple approaches for Discord enhanced embeds
+    // 1. Single high-quality icon for branding
     html += `  <link href="${FIXEMBED_LOGO}" rel="icon" type="image/png">\n`;
+
+    // 2. Apple touch icon for mobile
     html += `  <link rel="apple-touch-icon" href="${FIXEMBED_LOGO}">\n`;
 
+    // 3. oEmbed link for Discord to fetch provider and engagement info
+    // Note: Previously excluded Instagram to force large images, but testing if it still works with oEmbed
     const oembedUrl = new URL('https://fixembed.app/oembed');
     oembedUrl.searchParams.set('url', embed.url);
     if (embed.siteName) oembedUrl.searchParams.set('provider', embed.siteName);
     if (embed.stats) oembedUrl.searchParams.set('stats', embed.stats);
     if (embed.authorName) oembedUrl.searchParams.set('author', embed.authorName);
-    if (embed.title) oembedUrl.searchParams.set('title', metaTitle);
-    if (embed.description) oembedUrl.searchParams.set('desc', metaDescription);
-
+    if (embed.title) oembedUrl.searchParams.set('title', embed.title);
+    if (embed.description) oembedUrl.searchParams.set('desc', embed.description.slice(0, 1000)); // Limit length for URL
     html += `  <link rel="alternate" type="application/json+oembed" href="${escape(oembedUrl.toString())}">\n`;
-    html += `  <link rel="alternate" type="application/activity+json" href="${escape(activityUrl)}">\n`;
 
-    if (isDiscord || isTelegram) {
-        html += `  <meta name="referrer" content="no-referrer">\n`;
-    }
 
+    // Close head and add redirect body
     html += `</head>
 <body>
   <p>Redirecting to <a href="${escape(embed.url)}">${escape(embed.url)}</a></p>
@@ -186,26 +158,26 @@ export const platformColors: Record<string, string> = {
  * Platform display names for branding
  */
 export const platformNames: Record<string, string> = {
-    twitter: 'Twitter',
-    instagram: 'Instagram',
-    reddit: 'Reddit',
-    threads: 'Threads',
-    pixiv: 'Pixiv',
-    bluesky: 'Bluesky',
-    bilibili: 'Bilibili',
-    youtube: 'YouTube',
+    twitter: '𝕏 Twitter',
+    instagram: '📷 Instagram',
+    reddit: '🔗 Reddit',
+    threads: '🧵 Threads',
+    pixiv: '🎨 Pixiv',
+    bluesky: '🦋 Bluesky',
+    bilibili: '📺 Bilibili',
+    youtube: '▶️ YouTube',
 };
 
 /**
  * Generate branded site name for consistent FixEmbed branding
- * Format: "FixEmbed - Platform" or "FixEmbed - Platform - Duration"
+ * Format: "FixEmbed • Platform" or "FixEmbed • Platform • Duration"
  */
 export function getBrandedSiteName(platform: string, extra?: string): string {
     const platformDisplay = platformNames[platform] || platform;
     if (extra) {
-        return `FixEmbed - ${platformDisplay} - ${extra}`;
+        return `FixEmbed • ${platformDisplay} • ${extra}`;
     }
-    return `FixEmbed - ${platformDisplay}`;
+    return `FixEmbed • ${platformDisplay}`;
 }
 
 /**
@@ -221,7 +193,7 @@ export function formatNumber(num: number): string {
 }
 
 /**
- * Format stats line for compact, clean metadata rows
+ * Format stats line with emojis for consistent display
  */
 export function formatStats(stats: {
     likes?: number;
@@ -232,20 +204,21 @@ export function formatStats(stats: {
 }): string {
     const parts: string[] = [];
 
+    // Only show stats that are defined AND greater than 0
     if (stats.comments !== undefined && stats.comments > 0) {
-        parts.push(`Replies ${formatNumber(stats.comments)}`);
+        parts.push(`💬 ${formatNumber(stats.comments)}`);
     }
     if (stats.retweets !== undefined && stats.retweets > 0) {
-        parts.push(`Reposts ${formatNumber(stats.retweets)}`);
+        parts.push(`🔁 ${formatNumber(stats.retweets)}`);
     }
     if (stats.likes !== undefined && stats.likes > 0) {
-        parts.push(`Likes ${formatNumber(stats.likes)}`);
+        parts.push(`❤️ ${formatNumber(stats.likes)}`);
     }
     if (stats.views !== undefined && stats.views > 0) {
-        parts.push(`Views ${formatNumber(stats.views)}`);
+        parts.push(`👁 ${formatNumber(stats.views)}`);
     }
     if (stats.shares !== undefined && stats.shares > 0) {
-        parts.push(`Shares ${formatNumber(stats.shares)}`);
+        parts.push(`↗️ ${formatNumber(stats.shares)}`);
     }
 
     return parts.join(' ');

--- a/service/src/utils/embed.ts
+++ b/service/src/utils/embed.ts
@@ -37,7 +37,6 @@ function buildActivityData(embed: EmbedData): string {
         ic: embed.authorAvatar || FIXEMBED_LOGO,
         s: embed.stats,
         u: embed.url,
-        fo: embed.footerOnlyActivity ? 1 : 0,
     };
 
     const json = JSON.stringify(payload);
@@ -46,7 +45,7 @@ function buildActivityData(embed: EmbedData): string {
 }
 
 function shouldExposeActivityPub(embed: EmbedData): boolean {
-    return embed.footerOnlyActivity || embed.platform === 'twitter' || embed.platform === 'bluesky' || embed.platform === 'threads';
+    return embed.platform === 'twitter' || embed.platform === 'bluesky' || embed.platform === 'threads';
 }
 
 /**

--- a/service/src/utils/embed.ts
+++ b/service/src/utils/embed.ts
@@ -186,7 +186,6 @@ export const platformColors: Record<string, string> = {
     threads: '#000000',
     pixiv: '#0096FA',
     bluesky: '#1185FE',
-    youtube: '#FF0000',
     bilibili: '#00A1D6',
 };
 

--- a/service/src/utils/embed.ts
+++ b/service/src/utils/embed.ts
@@ -44,10 +44,6 @@ function buildActivityData(embed: EmbedData): string {
     return encoded.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 }
 
-function shouldExposeActivityPub(embed: EmbedData): boolean {
-    return embed.platform === 'twitter' || embed.platform === 'bluesky' || embed.platform === 'threads';
-}
-
 /**
  * Generate Open Graph meta tags for Discord/Telegram embeds
  */
@@ -137,9 +133,7 @@ export function generateEmbedHTML(embed: EmbedData, userAgent: string): string {
     if (embed.description) oembedUrl.searchParams.set('desc', metaDescription);
 
     html += `  <link rel="alternate" type="application/json+oembed" href="${escape(oembedUrl.toString())}">\n`;
-    if (shouldExposeActivityPub(embed)) {
-        html += `  <link rel="alternate" type="application/activity+json" href="${escape(activityUrl)}">\n`;
-    }
+    html += `  <link rel="alternate" type="application/activity+json" href="${escape(activityUrl)}">\n`;
 
     if (isDiscord || isTelegram) {
         html += `  <meta name="referrer" content="no-referrer">\n`;

--- a/service/tests/run-tests.ts
+++ b/service/tests/run-tests.ts
@@ -176,7 +176,7 @@ const tests: TestCase[] = [
         },
     },
     {
-        name: 'generateEmbedHTML exposes footer-only ActivityPub metadata for Reddit cards',
+        name: 'generateEmbedHTML does not expose ActivityPub metadata for Reddit cards',
         run: () => {
             const html = generateEmbedHTML({
                 title: 'How to change the owner of a pet?',
@@ -188,11 +188,10 @@ const tests: TestCase[] = [
                 image: 'https://cdn.example/reddit-thumb.jpg',
                 color: '#FF4500',
                 platform: 'reddit',
-                footerOnlyActivity: true,
             }, 'Discordbot/2.0');
 
             assert.match(html, /application\/json\+oembed/);
-            assert.match(html, /application\/activity\+json/);
+            assert.doesNotMatch(html, /application\/activity\+json/);
             assert.match(html, /og:title" content="How to change the owner of a pet\?"/);
             assert.match(html, /og:site_name" content="r\/Minecraft"/);
         },

--- a/service/tests/run-tests.ts
+++ b/service/tests/run-tests.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { findHandler } from '../src/handlers/index.ts';
 import { twitterHandler } from '../src/handlers/twitter.ts';
 import type { Env } from '../src/types.ts';
-import { formatStats, generateEmbedHTML, getBrandedSiteName } from '../src/utils/embed.ts';
+import { assessProbeResult } from '../src/utils/status.ts';
 import {
     cleanUrl,
     parseBlueskyUrl,
@@ -128,51 +128,30 @@ const tests: TestCase[] = [
         },
     },
     {
-        name: 'generateEmbedHTML includes oEmbed and ActivityPub metadata for rich cards',
+        name: 'status probes treat redirects as operational instead of outages',
         run: () => {
-            const html = generateEmbedHTML({
-                title: 'Netflix Anime (@NetflixAnime)',
-                description: 'A heartwarming yet humorous story awaits.',
-                url: 'https://x.com/NetflixAnime/status/1',
-                siteName: getBrandedSiteName('twitter'),
-                authorName: '@NetflixAnime',
-                authorHandle: '@NetflixAnime',
-                authorAvatar: 'https://cdn.example/avatar.jpg',
-                image: 'https://cdn.example/post.jpg',
-                color: '#111111',
-                platform: 'twitter',
-                stats: formatStats({ comments: 61, retweets: 539, likes: 2500, views: 59500 }),
-            }, 'Discordbot/2.0');
+            const assessment = assessProbeResult({
+                success: false,
+                redirect: 'https://fxtwitter.com/openai/status/1234567890',
+                error: 'Redirecting to FxTwitter',
+            }, 120);
 
-            assert.match(html, /application\/json\+oembed/);
-            assert.match(html, /application\/activity\+json/);
-            assert.match(html, /og:image:alt/);
-            assert.match(html, /twitter:image:alt/);
-            assert.match(html, /Netflix Anime \(@NetflixAnime\)/);
+            assert.equal(assessment.status, 'operational');
+            assert.equal(assessment.notice, null);
+            assert.equal(assessment.responseCode, 302);
         },
     },
     {
-        name: 'generateEmbedHTML includes video dimensions for video embeds',
+        name: 'status probes downgrade stale sample content errors to degraded',
         run: () => {
-            const html = generateEmbedHTML({
-                title: '@creator',
-                description: 'Clip preview',
-                url: 'https://www.instagram.com/reel/abc123/',
-                siteName: getBrandedSiteName('instagram'),
-                image: 'https://cdn.example/thumb.jpg',
-                video: {
-                    url: 'https://cdn.example/video.mp4',
-                    width: 720,
-                    height: 1280,
-                    thumbnail: 'https://cdn.example/thumb.jpg',
-                },
-                color: '#E4405F',
-                platform: 'instagram',
-            }, 'Discordbot/2.0');
+            const assessment = assessProbeResult({
+                success: false,
+                error: 'HTTP 404: Not Found',
+            }, 180);
 
-            assert.match(html, /og:video:width" content="720"/);
-            assert.match(html, /og:video:height" content="1280"/);
-            assert.match(html, /twitter:card" content="summary_large_image"/);
+            assert.equal(assessment.status, 'degraded');
+            assert.equal(assessment.notice, 'HTTP 404: Not Found');
+            assert.equal(assessment.responseCode, 424);
         },
     },
 ];

--- a/service/tests/run-tests.ts
+++ b/service/tests/run-tests.ts
@@ -175,27 +175,6 @@ const tests: TestCase[] = [
             assert.match(html, /twitter:card" content="summary_large_image"/);
         },
     },
-    {
-        name: 'generateEmbedHTML does not expose ActivityPub metadata for Reddit cards',
-        run: () => {
-            const html = generateEmbedHTML({
-                title: 'How to change the owner of a pet?',
-                description: 'I just bought an original copy of minecraft...',
-                url: 'https://reddit.com/r/Minecraft/comments/example/how_to_change/',
-                siteName: 'r/Minecraft',
-                authorName: 'Posted by u/[deleted]',
-                authorHandle: 'u/[deleted]',
-                image: 'https://cdn.example/reddit-thumb.jpg',
-                color: '#FF4500',
-                platform: 'reddit',
-            }, 'Discordbot/2.0');
-
-            assert.match(html, /application\/json\+oembed/);
-            assert.doesNotMatch(html, /application\/activity\+json/);
-            assert.match(html, /og:title" content="How to change the owner of a pet\?"/);
-            assert.match(html, /og:site_name" content="r\/Minecraft"/);
-        },
-    },
 ];
 
 async function main() {

--- a/service/tests/run-tests.ts
+++ b/service/tests/run-tests.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { findHandler } from '../src/handlers/index.ts';
 import { twitterHandler } from '../src/handlers/twitter.ts';
 import type { Env } from '../src/types.ts';
-import { formatStats, generateEmbedHTML, getBrandedSiteName, platformColors } from '../src/utils/embed.ts';
+import { formatStats, generateEmbedHTML, getBrandedSiteName } from '../src/utils/embed.ts';
 import {
     cleanUrl,
     parseBlueskyUrl,
@@ -195,12 +195,6 @@ const tests: TestCase[] = [
             assert.match(html, /application\/activity\+json/);
             assert.match(html, /og:title" content="How to change the owner of a pet\?"/);
             assert.match(html, /og:site_name" content="r\/Minecraft"/);
-        },
-    },
-    {
-        name: 'platformColors includes YouTube branding color',
-        run: () => {
-            assert.equal(platformColors.youtube, '#FF0000');
         },
     },
 ];


### PR DESCRIPTION
## Summary
- revert PR #34, PR #33, PR #32, and PR #31 in reverse order
- restore the service behavior to the state before `Polish embed service metadata` merged
- bring the test suite back to the pre-#31 expectations

## Verification
- ran `npm test` in `service`
- 11/11 tests passed
